### PR TITLE
Token.sol fundAccount function

### DIFF
--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -12,14 +12,18 @@ contract Token is Initializable,OwnableUpgradeable,ERC20Upgradeable{
 
     uint256 public fundAmount;
 
+    uint256 internal amountCheck;
+
     function initialize(string memory name, string memory symbol) public initializer  {
         __ERC20_init(name,symbol);
 
         __Ownable_init();
+
+        amountCheck = 0;
     }
 
    function mint(uint256 amount) public onlyOwner {
-        require(amount > 0, "Token: Amount cannot be 0");
+        require(amount > amountCheck, "Token: Amount cannot be 0");
         _mint(address(this), amount);
     }
 
@@ -29,7 +33,7 @@ contract Token is Initializable,OwnableUpgradeable,ERC20Upgradeable{
         uint256 previousAmount = fundAmount;
 
         // Prevents the fundAmount from being set to 0
-        require(amount > 0, "Token: Amount cannot be set to 0");
+        require(amount > amountCheck, "Token: Amount cannot be set to 0");
 
         // Sets the new fundAmount
         fundAmount = amount;
@@ -41,7 +45,9 @@ contract Token is Initializable,OwnableUpgradeable,ERC20Upgradeable{
 
     function fundAccount() public {
 
+        // Transfers the fundAmount to the msg.sender
         ERC20Upgradeable(address(this)).transfer(msg.sender, fundAmount);
+
     }
 }
 


### PR DESCRIPTION
## Summary
Closes #5 

## Implementation
 - [x] Configured the `fundAmount` variable with a default value of 0
 - [x] Configured the `setFundAmount` function that only allows the owner to set the `fundAmount` variable value
 - [x] Configured the `FundAmountSet` event that emits the previous and new `fundAmount` variable value when the owner invokes the `setFundAmount` function
- [x] Added the `fundAccount` function to the Token contract that allows any public address to invoke it and receive the `fundAmount` set by the owner
- [x] Provided unit tests to ensure functionality

## Files
```contracts/Token.sol```
```test/token.test.ts```

## Visual Preview
<img width="679" alt="Screen Shot 2022-03-19 at 6 38 39 PM" src="https://user-images.githubusercontent.com/42893948/159140825-4c5bef8b-dcb4-46f6-b374-1113cbbecc2a.png">

