### PR TITLE
Implement the `DoctorContractSet` event within `IHealthRecord.sol` and `HealthRecord.sol`

### DIFF
--- a/contracts/HealthRecord.sol
+++ b/contracts/HealthRecord.sol
@@ -22,6 +22,8 @@ contract HealthRecord is IHealthRecord, Initializable, OwnableUpgradeable {
     function setDoctorContract(address _doctorContract) public onlyOwner {
         doctorContractConfigured = true;
         doctorContract = _doctorContract;
+
+        emit DoctorContractSet(owner(), doctorContract, true, block.timestamp);
     }
 
     function addDoctor(address doctor, bytes32 cid) external {

--- a/contracts/interfaces/IHealthRecord.sol
+++ b/contracts/interfaces/IHealthRecord.sol
@@ -2,6 +2,13 @@
 pragma solidity 0.8.19;
 
 interface IHealthRecord {
+    event DoctorContractSet(
+        address owner,
+        address doctorContract,
+        bool isSet,
+        uint256 dateSet
+    );
+
     struct DoctorInformation {
         bytes32 cid;
         bytes32 filename;

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -57,6 +57,25 @@ describe.only("Doctor", function () {
       expect(queryFilter.args.newOwner).to.equal(signers[0].address);
     });
 
+    it("Should emit the DoctorContractSet event", async () => {
+      const filter = healthRecord.filters.DoctorContractSet(
+        null,
+        null,
+        null,
+        null
+      );
+
+      const queryFilter = (await healthRecord.queryFilter(filter))[0];
+
+      expect(queryFilter.event).to.equal("DoctorContractSet");
+      expect(queryFilter.args.owner).to.equal(await healthRecord.owner());
+      expect(queryFilter.args.doctorContract).to.equal(doctor.address);
+      expect(queryFilter.args.doctorContract).to.equal(
+        await healthRecord.doctorContract()
+      );
+      expect(queryFilter.args.isSet).to.be.true;
+    });
+
     it("Should get the owner", async () => {
       const owner = await doctor.owner();
 


### PR DESCRIPTION
## Summary
Closes #22 

The `DoctorContractSet` event definition within `contracts/interfaces/IHealthRecord.sol`
<img width="328" alt="Screenshot 2023-03-31 at 4 10 45 PM" src="https://user-images.githubusercontent.com/42893948/229220330-4f4234c8-a19e-41fd-beb8-1a7eed0ec65d.png">

The `DoctorContractSet` event emitter when `setDoctorContract` is invoked within `contracts/HealthRecord.sol`
<img width="709" alt="Screenshot 2023-03-31 at 4 11 32 PM" src="https://user-images.githubusercontent.com/42893948/229220420-312f2bbf-2d5e-4914-be17-21b268f9fafc.png">

## Files
`contracts/interfaces/IHealthRecord.sol`
`contracts/HealthRecord.sol`
`test/doctor.test.ts`

## Passing Tests
<img width="548" alt="Screenshot 2023-03-31 at 4 15 19 PM" src="https://user-images.githubusercontent.com/42893948/229221012-865b255f-f828-400e-b92a-f6059f335905.png">
