### PR TITLE
Prevent the `setDoctorContract` function from being invoked more than once

### DIFF
--- a/contracts/HealthRecord.sol
+++ b/contracts/HealthRecord.sol
@@ -20,6 +20,7 @@ contract HealthRecord is IHealthRecord, Initializable, OwnableUpgradeable {
     }
 
     function setDoctorContract(address _doctorContract) public onlyOwner {
+        require(!doctorContractConfigured, "HealthRecord: Doctor.sol is set");
         doctorContractConfigured = true;
         doctorContract = _doctorContract;
 

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -49,7 +49,7 @@ describe.only("Doctor", function () {
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
-    it("Should revert if Doctor contract is already set", async () => {
+    it("Should revert if the Doctor contract is already set", async () => {
       await expect(
         healthRecord.setDoctorContract(doctor.address)
       ).to.be.revertedWith("HealthRecord: Doctor.sol is set");

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -49,6 +49,12 @@ describe.only("Doctor", function () {
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
+    it("Should revert if Doctor contract is already set", async () => {
+      await expect(
+        healthRecord.setDoctorContract(doctor.address)
+      ).to.be.revertedWith("HealthRecord: Doctor.sol is set");
+    });
+
     it("Should emit the OwnershipTransferred on deployment", async () => {
       const filter = doctor.filters.OwnershipTransferred(null, null);
 


### PR DESCRIPTION
## Summary
Closes #26 

`require(!doctorContractConfigured, "HealthRecord: Doctor.sol is set");` prevents `setDoctorContract` from being invoked more than once
<img width="765" alt="Screenshot 2023-03-31 at 7 12 33 PM" src="https://user-images.githubusercontent.com/42893948/229248355-52162079-b51e-4868-a87c-adc97868f88a.png">

<img width="769" alt="Screenshot 2023-03-31 at 7 13 42 PM" src="https://user-images.githubusercontent.com/42893948/229248449-2b0dcc65-e1d6-4e0b-b70c-169b5b0a1b47.png">

## Files
`contracts/Doctor.sol`
`test/doctor.test.ts`

## Passing Tests
<img width="654" alt="Screenshot 2023-03-31 at 7 12 07 PM" src="https://user-images.githubusercontent.com/42893948/229248336-02f3be85-6eb6-4861-b66c-51f5ec98657f.png">
